### PR TITLE
allow additional providers when opening a panel from lazy module

### DIFF
--- a/projects/ngx-panels/src/lib/services/panel.service.ts
+++ b/projects/ngx-panels/src/lib/services/panel.service.ts
@@ -24,7 +24,7 @@ export class PanelService implements IPanelService {
         private readonly panelStatusService: PanelStatusService
     ) {}
 
-    // this method must not be called manually
+    // this method must not be called manually 
     setContainer(panelContainer: PanelContainerComponent) {
         if (this.panelContainer) {
             throw Error('You are using two <ngx-panel-containers> inside HTML. Please leave just one.');


### PR DESCRIPTION
Allow consumer to pass additional providers to the injector created for the panel. 

## Description
If a component rendered inside the panel has a dependency provided in the lazy module, then this provider will not be resolved. This change allows the consumer to pass additional providers when opening a panel. These providers are added to the injector for the panel and hence are available to any components within.

## Motivation and Context
Allow library to be used with lazy modules. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
