### PR TITLE
Add "panelOpenAnimationEnd" event

### DIFF
--- a/projects/ngx-panels/package.json
+++ b/projects/ngx-panels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verizon/ngx-panels",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "peerDependencies": {
     "@angular/common": "^7.0.0",
     "@angular/core": "^7.0.0"

--- a/projects/ngx-panels/src/fakes/panel-fake.component.ts
+++ b/projects/ngx-panels/src/fakes/panel-fake.component.ts
@@ -11,6 +11,7 @@ export class PanelFakeComponent implements IPanelComponent {
     contentContainer: any = {
         insert: jasmine.createSpy('insert')
     };
+    panelOpenAnimationEnd: EventEmitter<boolean> = new EventEmitter<boolean>();
     panelCloseAnimationEnd: EventEmitter<boolean> = new EventEmitter<boolean>();
     startCloseAnimation: jasmine.Spy = jasmine.createSpy('startCloseAnimation');
     onAnimationEvent: jasmine.Spy = jasmine.createSpy('onAnimationEvent');

--- a/projects/ngx-panels/src/lib/classes/panel-ref.class.ts
+++ b/projects/ngx-panels/src/lib/classes/panel-ref.class.ts
@@ -4,8 +4,6 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { PanelContainerComponent } from '../components/panel-container/panel-container.component';
 import { IPanelComponent } from '../components/panel/panel.interface';
 
-
-
 export interface IPanelRef<Data> {
     readonly closeEnabled$: Observable<boolean>;
     readonly data: Data;
@@ -21,6 +19,8 @@ export class PanelRef<Data> implements IPanelRef<Data> {
     private panelCmpRef: ComponentRef<IPanelComponent>;
     private panelContainer: PanelContainerComponent;
     private panelData: Data;
+
+    public guestComponent: any;
 
     private closeEnabledSubject: BehaviorSubject<boolean> = new BehaviorSubject(true);
 

--- a/projects/ngx-panels/src/lib/components/panel/panel.component.ts
+++ b/projects/ngx-panels/src/lib/components/panel/panel.component.ts
@@ -101,6 +101,9 @@ const ANIMATION_FLOATING_VISIBLE = {
 })
 export class PanelComponent implements IPanelComponent, OnInit {
     @Output()
+    panelOpenAnimationEnd: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+    @Output()
     panelCloseAnimationEnd: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     @ViewChild('contentContainer', { read: ViewContainerRef, static: true })
@@ -118,9 +121,19 @@ export class PanelComponent implements IPanelComponent, OnInit {
     }
 
     onAnimationEvent(evt: AnimationEvent) {
-        if (evt.fromState !== 'void' && this.isClosed(evt.toState)) {
+        if (evt.fromState === 'void' && this.isOpen(evt.toState)) {
+            this.panelOpenAnimationEnd.emit(true);
+        } else if (evt.fromState !== 'void' && this.isClosed(evt.toState)) {
             this.panelCloseAnimationEnd.emit(true);
         }
+    }
+
+    private isOpen(evtState: string): boolean {
+        return evtState === OPEN_RIGHT
+            || evtState === OPEN_LEFT
+            || evtState === OPEN_TOP
+            || evtState === OPEN_BOTTOM
+            || evtState === OPEN_FLOATING;
     }
 
     private isClosed(evtState: string): boolean {
@@ -137,6 +150,11 @@ export class PanelComponent implements IPanelComponent, OnInit {
 
     private openState(): string {
         return `open-${this.config.side}`;
+    }
+
+    startOpenAnimation() {
+        this.panelState = this.openState();
+        this.ref.markForCheck();
     }
 
     startCloseAnimation() {

--- a/projects/ngx-panels/src/lib/components/panel/panel.interface.ts
+++ b/projects/ngx-panels/src/lib/components/panel/panel.interface.ts
@@ -5,6 +5,7 @@ import { EventEmitter, ViewContainerRef } from '@angular/core';
 
 export interface IPanelComponent {
     contentContainer: ViewContainerRef;
+    panelOpenAnimationEnd: EventEmitter<boolean>;
     panelCloseAnimationEnd: EventEmitter<boolean>;
     onAnimationEvent(evt: AnimationEvent);
 

--- a/projects/ngx-panels/src/lib/services/panel.service.ts
+++ b/projects/ngx-panels/src/lib/services/panel.service.ts
@@ -24,7 +24,7 @@ export class PanelService implements IPanelService {
         private readonly panelStatusService: PanelStatusService
     ) {}
 
-    // this method must not be called manually 
+    // this method must not be called manually
     setContainer(panelContainer: PanelContainerComponent) {
         if (this.panelContainer) {
             throw Error('You are using two <ngx-panel-containers> inside HTML. Please leave just one.');
@@ -47,9 +47,10 @@ export class PanelService implements IPanelService {
     }
 
     open<Content, Data>(content: Type<Content>, data?: Data, providers?: StaticProvider[]): PanelRef<Data> {
+        const wasOpenBefore: boolean = this.panelStatusService.isOpen;
         this.panelStatusService.increment();
         const panelRef: PanelRef<Data> = this.appendPanel(PanelComponent, content, data, providers);
-        if (!this.panelStatusService.isOpen) {
+        if (!wasOpenBefore) {
             this.panelStatusService.notifyOpen();
         }
         return panelRef;
@@ -86,6 +87,7 @@ export class PanelService implements IPanelService {
             panelRef.setData(data);
         }
         panelComponentRef.instance.contentContainer.insert(contentComponentRef.hostView);
+        panelRef.guestComponent = contentComponentRef.instance;
 
         this.panelContainer.addTopPanel(panelRef);
 


### PR DESCRIPTION
If there is a `panelCloseAnimationEnd`, why not to add the `panelOpenAnimationEnd` event?